### PR TITLE
Remove documentation of (discontinued) removal of special passages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Aside from the obvious benefits of a "use your own editor" solution, Twee2 provi
 ## Notes
 
 * This is not a Twee to Harlowe converter. You'll still need to change your macros as described at http://twine2.neocities.org/, and/or rewrite them as Javascript code. However, it might help your efforts to update Twee sources to Twine 2 output.
-* Some special story segments (e.g. StorySubtitle) used in Twee 1 are ignored. You will be warned when this happens.
 * The Twine 2 editor might not be able to re-open stories compiled using Twee2, because Twee2 does not automatically include positional data used by the visual editor (however, you can add this manually if you like).
 
 ## Build

--- a/lib/twee2/story_file.rb
+++ b/lib/twee2/story_file.rb
@@ -68,7 +68,7 @@ module Twee2
       # Run each passage through a preprocessor, if required
       run_preprocessors
       # Extract 'special' passages and mark them as not being included in output
-      story_css, pid, @story_js, @story_start_pid, @story_start_name = '', 0, '', nil, 'Start'
+      @story_css, pid, @story_js, @story_start_pid, @story_start_name = '', 0, '', nil, 'Start'
       @passages.each_key do |k|
         if k == 'StoryTitle'
           Twee2::build_config.story_name = @passages[k][:content]
@@ -76,7 +76,7 @@ module Twee2
         elsif k == 'StoryIncludes'
           @passages[k][:exclude_from_output] = true # includes should already have been handled above
         elsif @passages[k][:tags].include? 'stylesheet'
-          story_css << "#{@passages[k][:content]}\n"
+          @story_css << "#{@passages[k][:content]}\n"
           @passages[k][:exclude_from_output] = true
         elsif @passages[k][:tags].include? 'script'
           @story_js << "#{@passages[k][:content]}\n"
@@ -101,7 +101,7 @@ module Twee2
                                       format: '{{STORY_FORMAT}}',
                                      options: ''
                       }) do
-        @story_data.style(story_css, role: 'stylesheet', id: 'twine-user-stylesheet', type: 'text/twine-css')
+        @story_data.style('{{STORY_CSS}}', role: 'stylesheet', id: 'twine-user-stylesheet', type: 'text/twine-css')
         @story_data.script('{{STORY_JS}}', role: 'script', id: 'twine-user-script', type: 'text/twine-javascript')
         @passages.each do |k,v|
           unless v[:exclude_from_output]
@@ -114,7 +114,7 @@ module Twee2
     # Returns the rendered XML that represents this story
     def xmldata
       data = @story_data.target!
-      data.gsub('{{STORY_JS}}', @story_js)
+      data.gsub('{{STORY_JS}}', @story_js).gsub('{{STORY_CSS}}', @story_css)
     end
 
     # Runs HAML, Coffeescript etc. preprocessors across each applicable passage


### PR DESCRIPTION
Just a minor tweak to the documentation, inspired by a Twee2 problem mentioned at the Twine forums (that turned out to be unrelated).