### PR TITLE
Pull information about a StoryFormat from the format file itself

### DIFF
--- a/lib/twee2/story_file.rb
+++ b/lib/twee2/story_file.rb
@@ -99,6 +99,7 @@ module Twee2
                          'creator-version' => Twee2::VERSION,
                                         ifid: Twee2::build_config.story_ifid,
                                       format: '{{STORY_FORMAT}}',
+							  'format-version': '{{STORY_FORMAT_VERSION}}',
                                      options: ''
                       }) do
         @story_data.style(story_css, role: 'stylesheet', id: 'twine-user-stylesheet', type: 'text/twine-css')

--- a/lib/twee2/story_format.rb
+++ b/lib/twee2/story_format.rb
@@ -9,6 +9,8 @@ module Twee2
       raise(StoryFormatNotFoundException) if !File::exists?(format_file_path = Twee2::buildpath("storyFormats/#{name}/format.js")) && !File::exists?(format_file_path = "#{name}/format.js")
       @name = name
       format_file = File::read(format_file_path)
+      @format_version = format_file.match(/(["'])version\1 *: *(["'])(.*?[^\\])\2/)[3]
+      @format_name = format_file.match(/(["'])name\1 *: *(["'])(.*?[^\\])\2/)[3]
       format_data = format_file.match(/(["'])source\1 *: *(["']).*?[^\\]\2/)[0]
       format_data_for_json = "\{#{format_data}\}"
       @source = JSON.parse(format_data_for_json)['source']
@@ -16,7 +18,7 @@ module Twee2
 
     # Given a story file, injects it into the StoryFormat and returns the HTML results
     def compile
-      @source.gsub('{{STORY_NAME}}', Twee2::build_config.story_name).gsub('{{STORY_DATA}}', Twee2::build_config.story_file.xmldata).gsub('{{STORY_FORMAT}}', @name)
+      @source.gsub('{{STORY_NAME}}', Twee2::build_config.story_name).gsub('{{STORY_DATA}}', Twee2::build_config.story_file.xmldata).gsub('{{STORY_FORMAT}}', @format_name).gsub('{{STORY_FORMAT_VERSION}}', @format_version)
     end
 
     # Returns an array containing the known StoryFormat names


### PR DESCRIPTION
These changes pull a StoryFormat's name and version directly from the StoryFormat .js file, and add the format's version to the compiled output as a `format-version` attribute on the `tw-storydata` tag. That matches the recent behavior of Twine, and means that we can go back to compiled stories and confirm what version of the story format was used. It also divorces story formats' names from the directory name in the `storyFormats` directory, which then supports having multiple versions of the same story format.