### PR TITLE
Add working Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# USAGE:
+# docker run --rm -it -v $(pwd):/work [image] build inputfile.twee index.html
+# Replace [image] with the appropriate image name
+
+FROM ruby:2.7
+
+WORKDIR /app
+
+COPY . /app
+
+RUN apt update && apt install -y nodejs
+RUN bundle install &&\
+    gem build twee2.gemspec &&\
+    gem install ./twee2-0.5.0.gem &&\
+    rm Gemfile.lock
+
+WORKDIR /work
+ENTRYPOINT ["twee2"]
+


### PR DESCRIPTION
This helps resolve #56 and addresses the issues in #59 

Specifically, that PR was missing the gem build steps, Nodejs dependency, and information about how to use volumes.

I've included a comment in the Dockerfile with a usage example. The goal is to be able to use this container interchangeably with the regular `twee2` command.

For those unfamiliar w/ Docker, you would first build the image with

`docker build -t twee2 .`

And then run the container with:

`docker run --rm -it -v $(pwd):/work twee2 build inputfile.twee outputfile.html`

which is equivalent to natively running

`twee2 build inputfile.twee outputfile.html`